### PR TITLE
Fix jq command to reference composer.json directly

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -16,7 +16,7 @@ PKG_SOURCE  := $(shell jq -r '.name' composer.json)
 
 override_dh_install:
 	mkdir -p debian/tmp
-	jq '.version = "'`dpkg-parsechangelog | sed -n 's/^Version: //p'| sed 's/~.*//'`'"'  debian/composer.json |sponge debian/tmp/composer.json
+	jq '.version = "'`dpkg-parsechangelog | sed -n 's/^Version: //p'| sed 's/~.*//'`'"'  composer.json |sponge debian/tmp/composer.json
 	dh_install
 	sed -i "s|: 'unknown'|: '$(PKG_SOURCE)'|" \
 		debian/php-vitexsoftware-ease-html-widgets/usr/share/php/EaseHtmlWidgets/autoload.php


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Debian package build process to handle version substitution during the installation staging phase.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/VitexSoftware/php-vitexsoftware-ease-html-widgets/pull/30)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->